### PR TITLE
Add Sveltia CMS for browser-based publishing

### DIFF
--- a/CMS-SETUP.md
+++ b/CMS-SETUP.md
@@ -1,0 +1,56 @@
+# Content editor (Sveltia CMS) — one-time setup
+
+The site now has a browser-based editor at **https://fuzzsgrill.com/admin**.
+Once writing a post is as easy as filling in a form and clicking **Publish** —
+no terminal, no git, no `hugo` commands.
+
+Everything is already wired up **except login**. The CMS needs permission to
+commit to the GitHub repo on your behalf, and that takes one ~15-minute setup.
+You only do this once.
+
+## What you need
+- Admin access to the `fuzzsgrill/fuzzsgrill.com` GitHub repo.
+- Access to the site's Netlify dashboard.
+
+## Step 1 — Create a GitHub OAuth App
+1. Go to GitHub → **Settings → Developer settings → OAuth Apps → New OAuth App**
+   (direct link: https://github.com/settings/developers).
+2. Fill in:
+   - **Application name:** `Fuzz's Grill CMS`
+   - **Homepage URL:** `https://fuzzsgrill.com`
+   - **Authorization callback URL:** `https://api.netlify.com/auth/done`
+3. Click **Register application**.
+4. Copy the **Client ID**, then click **Generate a new client secret** and copy
+   the secret. (Keep the tab open — you'll paste both into Netlify next.)
+
+## Step 2 — Tell Netlify about it
+1. In the Netlify dashboard, open the **fuzzsgrill.com** site.
+2. Go to **Site configuration → Access & security → OAuth**
+   (older UI: **Site settings → Access control → OAuth**).
+3. Under **Authentication providers**, click **Install provider** and choose
+   **GitHub**.
+4. Paste the **Client ID** and **Client Secret** from Step 1. Save.
+
+## Step 3 — Log in and write a post
+1. Go to **https://fuzzsgrill.com/admin**.
+2. Click **Login with GitHub** and authorize.
+3. Click **New Blog Post**, fill in Title / Date / Summary, write the body,
+   turn the **Draft** toggle **off**, and hit **Publish**.
+4. Netlify rebuilds automatically; the post is live in about a minute.
+
+That's it. From now on, all writing happens at `/admin`.
+
+---
+
+### Notes
+- The editor commits straight to the `main` branch. The old habit of making a
+  new git branch per post is no longer needed.
+- Images dragged into the editor are saved to `static/images` and inserted
+  automatically.
+- The login config lives in `static/admin/config.yml`; the editor page itself is
+  `static/admin/index.html`. Hugo publishes both to `/admin` automatically.
+
+### Alternative login (no Netlify OAuth)
+If you ever move off Netlify, Sveltia can authenticate through a small free
+Cloudflare Worker instead — see https://github.com/sveltia/sveltia-cms-auth.
+You'd then add a `base_url` line to `config.yml` pointing at that worker.

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,0 +1,45 @@
+backend:
+  name: github
+  repo: fuzzsgrill/fuzzsgrill.com
+  branch: main
+  # Login is handled by an OAuth provider. With Netlify's OAuth provider set up
+  # (see CMS-SETUP.md), no base_url is needed here — the default points at it.
+
+# Where the CMS uploads images, and the URL they resolve to on the live site.
+media_folder: static/images
+public_folder: /images
+
+# Links the CMS back to the live site.
+site_url: https://fuzzsgrill.com
+display_url: https://fuzzsgrill.com
+
+collections:
+  - name: blog
+    label: Blog Posts
+    label_singular: Blog Post
+    description: Write a new post or edit an existing one, then hit Publish.
+    folder: content/blog
+    create: true
+    slug: "{{slug}}"
+    # His posts use TOML frontmatter (the +++ block).
+    format: toml-frontmatter
+    sortable_fields: [date, title]
+    fields:
+      - { name: title, label: Title, widget: string }
+      - {
+          name: date,
+          label: Date,
+          widget: datetime,
+          date_format: "YYYY-MM-DD",
+          time_format: false,
+          format: "YYYY-MM-DD",
+        }
+      - { name: summary, label: Summary, widget: string, required: false }
+      - {
+          name: draft,
+          label: "Draft (leave on while writing; turn OFF to publish)",
+          widget: boolean,
+          default: true,
+        }
+      - { name: layout, label: Layout, widget: hidden, default: simple }
+      - { name: body, label: Body, widget: markdown }

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fuzz's Grill — Content Manager</title>
+  </head>
+  <body>
+    <!-- Sveltia CMS: actively-maintained successor to Decap/Netlify CMS -->
+    <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## What this does

Adds a git-based CMS at **`/admin`** so posts can be written and published from the browser — no terminal, git, or Hugo commands needed. The existing Hugo site, Congo theme, content, and Netlify hosting all stay exactly as-is.

## Changes
- **`static/admin/index.html`** — loads [Sveltia CMS](https://github.com/sveltia/sveltia-cms), the actively-maintained successor to Decap/Netlify CMS (logs in via GitHub directly, since Netlify Identity is deprecated).
- **`static/admin/config.yml`** — blog collection mapped to `content/blog` using the existing TOML frontmatter fields (`title`, `date`, `summary`, `draft`, `layout`); image uploads go to `static/images`; dates stored as `YYYY-MM-DD` to match current posts.
- **`CMS-SETUP.md`** — the one-time GitHub OAuth + Netlify steps, which are the only remaining manual setup.

## Verification
- Builds clean on the pinned **Hugo 0.145.0**; `/admin/index.html` + `config.yml` land in the published output.
- `config.yml` is valid YAML and parses to the expected structure (backend → `fuzzsgrill/fuzzsgrill.com@main`, fields `title/date/summary/draft/layout/body`).

## Remaining manual step (after merge)
The editor goes live at `fuzzsgrill.com/admin` once this is on `main` and Netlify redeploys. Login still needs a one-time GitHub OAuth app wired into Netlify's OAuth provider — see `CMS-SETUP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)